### PR TITLE
Require toml package for Python versions before 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     "jupysql-plugin>=0.4.2",
     "ploomber-core>=0.2.7",
     "ploomber-extension",
+    'toml;python_version<"3.11"',
 ]
 
 DEV = [

--- a/src/sql/magic.py
+++ b/src/sql/magic.py
@@ -756,13 +756,6 @@ def load_SqlMagic_configs(ip):
                 f"check that it is valid TOML: {e}"
             )
             return
-        if type(e).__name__ == "ModuleNotFoundError":
-            display.message(
-                "The 'toml' package isn't installed. To load settings from "
-                "pyproject.toml or ~/.jupysql/config, install with: "
-                "pip install toml"
-            )
-            return
         else:
             raise
 

--- a/src/sql/util.py
+++ b/src/sql/util.py
@@ -17,7 +17,7 @@ from jinja2 import Template
 try:
     import toml
 except ModuleNotFoundError:
-    toml = None
+    import tomllib as toml
 
 SINGLE_QUOTE = "'"
 DOUBLE_QUOTE = '"'

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -498,24 +498,6 @@ displaycon = false
     assert all([getattr(sql, config) == value for config, value in confirm.items()])
 
 
-def test_toml_optional_message(tmp_empty, monkeypatch, ip, capsys):
-    monkeypatch.setitem(sys.modules, "toml", None)
-    Path("pyproject.toml").write_text(
-        """
-[tool.jupysql.SqlMagic]
-autocommit = true
-"""
-    )
-
-    ip.run_cell("%load_ext sql")
-    out, _ = capsys.readouterr()
-    assert (
-        "The 'toml' package isn't installed. "
-        "To load settings from pyproject.toml or ~/.jupysql/config, "
-        "install with: pip install toml"
-    ) in out
-
-
 @pytest.mark.parametrize(
     "pyproject_content, config_content, expected_messages",
     [


### PR DESCRIPTION
Starting with Python 3.11, the standard library has TOML parsing with tomllib.

## Describe your changes

## Issue number

Closes #X

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)

